### PR TITLE
add the possibility to get the resolved router outside of make_into_service

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,6 +293,11 @@ where
     pub fn routes(&self) -> &HashMap<String, PathBuf> {
         &self.routes
     }
+
+    /// Convert into a [`Router`](axum::Router) after adding an [`Routes`] as an [`Extension`](axum::extract::Extension) layer
+    pub fn into_router(self) -> axum::Router<S, B> {
+        self.inner.layer(Extension(Routes::new(self.routes)))
+    }
 }
 
 impl<B> NamedRouter<(), B>
@@ -303,7 +308,7 @@ where
     /// adding an [`Extension<Routes>`](axum::extract::Extension) layer to the inner router
     #[cfg(feature = "tokio")]
     pub fn into_make_service(self) -> IntoMakeService<axum::Router<(), B>> {
-        let inner = self.inner.layer(Extension(Routes::new(self.routes)));
+        let inner = self.into_router();
         inner.into_make_service()
     }
 
@@ -313,7 +318,7 @@ where
     pub fn into_make_service_with_connect_info<C>(
         self,
     ) -> IntoMakeServiceWithConnectInfo<axum::Router<(), B>, C> {
-        let inner = self.inner.layer(Extension(Routes::new(self.routes)));
+        let inner = self.into_router();
         inner.into_make_service_with_connect_info()
     }
 }


### PR DESCRIPTION
Reason:
I use `NormalizePathLayer::trim_trailing_slash()` to trim trailing path slashes.

that means i have to call `into_make_service` on the `NormalizePathLayer`, thus it doesn't get called on the `NamedRouter`.

Adding that method allows me to convert the `NamedRouter` into a `Router` manually and resolve the `Routes` Extension.